### PR TITLE
CL_SAFESTRAFE: can enable safestrafe mode in the client

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -2630,6 +2630,27 @@
       "group-id": "53",
       "type": "float"
     },
+    "cl_safestrafe": {
+      "default": "0",
+      "desc": "Enables safestrafe mode in client regardless of server enforcement.",
+      "group-id": "9",
+      "remarks": "Safestrafe is a serverside SOCD fairness feature that requires one or more stop frames between direction changes.",
+      "type": "integer",
+      "values": [
+        {
+          "description": "Disabled",
+          "name": "0 "
+        },
+        {
+          "description": "Enabled (requires one stop frame between direction changes)",
+          "name": "1 "
+        },
+        {
+          "description": "Sets the number of required stop frames between direction changes.",
+          "name": "2+"
+        }
+      ]
+    },
     "cl_savehistory": {
       "default": "1",
       "desc": "Save console commands history to .ezquake_history. Loads history from this file while starting ezquake.",

--- a/src/cl_input.c
+++ b/src/cl_input.c
@@ -36,6 +36,7 @@ cvar_t cl_movespeedkey = { "cl_movespeedkey","2.0" };
 cvar_t cl_nodelta = { "cl_nodelta","0" };
 cvar_t cl_pitchspeed = { "cl_pitchspeed","150" };
 cvar_t cl_upspeed = { "cl_upspeed","400" };
+cvar_t cl_safestrafe = {"cl_safestrafe", "0"};
 cvar_t cl_sidespeed = { "cl_sidespeed","400" };
 cvar_t cl_yawspeed = { "cl_yawspeed","140" };
 cvar_t cl_weaponhide = { "cl_weaponhide", "0" };
@@ -989,7 +990,8 @@ int cmdtime_msec = 0;
 
 void CL_ApplySafestrafe(usercmd_t *cmd)
 {
-	int required_frames = movevars.safestrafe;
+	int required_frames = max(movevars.safestrafe, cl_safestrafe.value);
+
 	if (required_frames <= 0)
 		return;
 	
@@ -1088,8 +1090,8 @@ void CL_SendCmd(void)
 		Cam_Track(cmd);
 	}
 
-	// Apply safestrafe if enabled on server
-	if (movevars.safestrafe > 0 && !cl.spectator) {
+	// Apply safestrafe if enabled on server or client
+	if ((movevars.safestrafe > 0 || cl_safestrafe.value > 0) && !cl.spectator) {
 		CL_ApplySafestrafe(cmd);
 	}
 
@@ -1281,6 +1283,7 @@ void CL_InitInput(void)
 	Cvar_Register(&cl_upspeed);
 	Cvar_Register(&cl_forwardspeed);
 	Cvar_Register(&cl_backspeed);
+	Cvar_Register(&cl_safestrafe);
 	Cvar_Register(&cl_sidespeed);
 	Cvar_Register(&cl_movespeedkey);
 	Cvar_Register(&cl_yawspeed);


### PR DESCRIPTION
This allows players to enable safestrafe on their own clients, even if the server doesn't require it.