### PR TITLE
Add discharge visualization

### DIFF
--- a/help_commands.json
+++ b/help_commands.json
@@ -505,6 +505,9 @@
   "dir": {
     "system-generated": true
   },
+  "dischargeradius": {
+    "description": "Visualizes the discharge radius as a temporary sphere around the player. The color of the sphere is controlled by r_dischargeLightColor."
+  },
   "disconnect": {
     "description": "This command will disconnect you from the server/demo/proxy you are currently connected to."
   },

--- a/help_variables.json
+++ b/help_variables.json
@@ -16991,6 +16991,28 @@
         }
       ]
     },
+    "r_dischargeLight": {
+      "default": "0",
+      "desc": "When enabled, draws a sphere around the discharge to indicate its reach. This feature requires the server to emit the //ktx discharge event.",
+      "group-id": "8",
+      "type": "bool",
+      "values": [
+        {
+          "description": "Disable dynamic discharge light.",
+          "name": "0"
+        },
+        {
+          "description": "Enable dynamic discharge lights.",
+          "name": "1"
+        }
+      ]
+    },
+    "r_dischargeLightColor": {
+      "default": "0 255 255",
+      "desc": "Changes color of the discharge light sphere.",
+      "group-id": "8",
+      "type": "string"
+    },
     "r_sgbloodColor": {
       "default": "73",
       "desc": "Determines the color of the blood particles emitted when hitting entities with weapons other than the lightning gun.",

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -70,6 +70,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_renderer.h"
 #include "r_performance.h"
 #include "r_program.h"
+#include "r_draw.h"
 
 extern qbool ActiveApp, Minimized;
 
@@ -215,6 +216,8 @@ cvar_t r_rocketlight            = {"r_rocketLight", "1"};
 cvar_t r_rocketlightcolor       = {"r_rocketLightColor", "0"};
 cvar_t r_explosionlightcolor    = {"r_explosionLightColor", "0"};
 cvar_t r_explosionlight         = {"r_explosionLight", "1"};
+cvar_t r_dischargelight         = {"r_dischargeLight", "0"};
+cvar_t r_dischargelightcolor    = {"r_dischargeLightColor", "0 255 255"};
 cvar_t r_flagcolor              = {"r_flagColor", "0"};
 cvar_t r_lightflicker           = {"r_lightflicker", "1"};
 cvar_t r_powerupglow            = {"r_powerupGlow", "1"};
@@ -1394,6 +1397,28 @@ void CL_Disconnect_f (void)
 	Host_EndGame();
 }
 
+void CL_DischargeRadius_f (void)
+{
+	int cells, timeout;
+
+	if (Cmd_Argc() != 3)
+	{
+		Com_Printf("Usage: %s <cells> <timeout>\n", Cmd_Argv(0));
+		return;
+	}
+
+	if (cls.state == ca_active && !cl.standby)
+	{
+		Com_Printf("%s is not available during games\n", Cmd_Argv(0));
+		return;
+	}
+
+	cells = atoi(Cmd_Argv(1));
+	timeout = atoi(Cmd_Argv(2));
+
+	DrawRadius((cells * 35) + 40, timeout, cl.simorg);
+}
+
 // The server is changing levels.
 void CL_Reconnect_f (void) 
 {
@@ -1860,6 +1885,8 @@ static void CL_InitLocal(void)
 	Cvar_Register(&r_explosionlight);
 	Cvar_Register(&r_rocketlightcolor);
 	Cvar_Register(&r_explosionlightcolor);
+	Cvar_Register(&r_dischargelight);
+	Cvar_Register(&r_dischargelightcolor);
 	Cvar_Register(&r_flagcolor);
 	Cvar_Register(&cl_fakeshaft);
 	Cvar_Register(&cl_fakeshaft_extra_updates);
@@ -2017,6 +2044,7 @@ static void CL_InitLocal(void)
 	Cmd_AddCommand ("dns", CL_DNS_f);
 	Cmd_AddCommand ("hash", CL_Hash_f);
 	Cmd_AddCommand ("reconnect", CL_Reconnect_f);
+	Cmd_AddCommand ("dischargeradius", CL_DischargeRadius_f);
 
 	Cmd_AddMacro(macro_connectiontype, CL_Macro_ConnectionType);
 	Cmd_AddMacro(macro_demoplayback, CL_Macro_Demoplayback);

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -3143,6 +3143,7 @@ void CL_ParsePrint (void)
 
 void CL_ParseStufftext (void) 
 {
+	extern cvar_t r_dischargelight;
 	char *s = MSG_ReadString();
 
 	// Always process demomarks, regardless of who inserted them
@@ -3195,6 +3196,12 @@ void CL_ParseStufftext (void)
 			if (cl.standby && !CL_Demo_SkipMessage(true)) {
 				// Ignore if not the tracked player
 				CL_ReadKtxDamageIndicatorString(s + 2);
+			}
+		}
+		else if (!strncmp(s, "//ktx discharge ", sizeof("//ktx discharge ") - 1)) {
+			if (r_dischargelight.value)
+			{
+				CL_ReadKtxDischargeString(s + 2);
 			}
 		}
 	}

--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -48,6 +48,7 @@ $Id: cl_screen.c,v 1.156 2007-10-29 00:56:47 qqshka Exp $
 #include "r_renderer.h"
 #include "r_matrix.h"
 #include "qsound.h"
+#include "r_draw.h"
 
 #ifndef CLIENTONLY
 #include "server.h"
@@ -1363,6 +1364,26 @@ void CL_ReadKtxDamageIndicatorString(const char* s)
 
 		CL_SpawnDamageIndicatorDirect(deathtype, origin, damage, splash_damage, team_damage);
 	}
+}
+
+void CL_ReadKtxDischargeString(const char* s)
+{
+	vec3_t origin;
+	int radius;
+
+	Cmd_TokenizeString((char*)s);
+
+	if (Cmd_Argc() != 6)
+	{
+		return;
+	}
+
+	radius = atoi(Cmd_Argv(2));
+	origin[0] = atof(Cmd_Argv(3));
+	origin[1] = atof(Cmd_Argv(4));
+	origin[2] = atof(Cmd_Argv(5));
+
+	DrawRadius(radius, 1, origin);
 }
 
 static void SCR_RegisterDamageIndicatorCvars(void)

--- a/src/mvd_utils.h
+++ b/src/mvd_utils.h
@@ -45,6 +45,7 @@ void MVDAnnouncer_PackDropped(const char* s);
 void MVDAnnouncer_Expired(const char* s);
 void MVDAnnouncer_BackpackPickup(const char* s);
 void CL_ReadKtxDamageIndicatorString(const char* s);
+void CL_ReadKtxDischargeString(const char* s);
 
 // Powerup cams
 qbool MVD_PowerupCam_Enabled(void);

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -1174,3 +1174,31 @@ qbool Draw_IsConsoleBackground(mpic_t* pic)
 {
 	return pic == &conback || pic == last_lvlshot;
 }
+
+void DrawRadius(int radius, int timeout, vec3_t origin)
+{
+	extern cvar_t r_dischargelightcolor;
+	dlight_t *dl = NULL;
+	customlight_t l = {0};
+	byte color[4];
+	int i;
+
+	StringToRGB_W(r_dischargelightcolor.string, color);
+
+	l.type = lt_custom;
+
+	for (i = 0; i < 3; i++)
+	{
+		l.color[i] = min(128, color[i]);
+	}
+
+	l.alpha = color[3];
+
+	dl = CL_AllocDlight(0);
+	VectorCopy(origin, dl->origin);
+	dl->radius = radius;
+	dl->die = cl.time + timeout;
+	dl->decay = timeout == 1 ? 300 : 0;
+	dl->type = lt_custom;
+	VectorCopy(l.color, dl->color);
+}

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -15,5 +15,6 @@ void R_Draw_StringBase_StartString(float x, float y, float scale);
 void R_Cache2DMatrix(void);
 void R_UndoLastCharacter(void);
 void R_Draw_Polygon(float x, float y, vec3_t *vertices, int num_vertices, color_t color);
+void DrawRadius(int radius, int timeout, vec3_t origin);
 
 #endif // EZQUAKE_R_DRAW_HEADER


### PR DESCRIPTION
This commit adds one new command and two new variables.

- dischargeradius
- r_dischargeLight
- r_dischargeLightColor

The dischargeradius command lets you visualize the radius of a discharge. The color of the sphere can be controlled by setting r_dischargeLightColor.

The discharge sphere can also be rendered automatically when playing on a KTX server that emits the //ktx discharge event. To enable this, set r_dischargeLight to 1.